### PR TITLE
Enabled auto collapse on sidebars

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,7 +102,6 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       image: 'img/eigencloud-logo-blue.png',
-
       navbar: {
         title: "EigenLayer",
         logo: {
@@ -196,6 +195,7 @@ const config = {
       docs: {
         sidebar: {
           hideable: true,
+          autoCollapseCategories: true,
         },
       },
       prism: {


### PR DESCRIPTION
The left menu is very long with the consolidation of sites - making this change so it's easier to navigate/not lose sight of the top level structure. 