### PR TITLE
docs: github icon should point to repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -674,7 +674,7 @@ const config = {
           },
 
           {
-            href: "https://github.com/Layr-Labs",
+            href: "https://github.com/Layr-Labs/eigencloud-docs",
             className: "header--github-link",
             "aria-label": "GitHub repository",
             position: "right",


### PR DESCRIPTION
Right now it points to github org, which I find confusing. Most of the time when I click on this icon I want to make a PR to improve the docs.