### PR TITLE
Updating and removing old links

### DIFF
--- a/docs/products/eigenda/networks/holesky.md
+++ b/docs/products/eigenda/networks/holesky.md
@@ -9,9 +9,8 @@ The EigenDA Holesky testnet is the EigenDA testnet for operators.
 ## Quick Links
 
 * [AVS Page][2]
-* [Blob Explorer V1][1]
 * [Blob Explorer Blazar (V2)][4]
-* [Deployed Contract Addresses][3]
+* [Blob Explorer V1][1]
 
 ## Specs
 
@@ -51,5 +50,4 @@ All other contracts are now tracked inside the EigenDADirectory contract:
 
 [1]: https://blobs-holesky.eigenda.xyz/
 [2]: https://holesky.eigenlayer.xyz/avs/eigenda
-[3]: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-testnet-deployment
 [4]: https://blobs-v2-testnet-holesky.eigenda.xyz/

--- a/docs/products/eigenda/networks/mainnet.md
+++ b/docs/products/eigenda/networks/mainnet.md
@@ -8,19 +8,6 @@ sidebar_position: 1
 
 * [AVS Page][2]
 * [Blob Explorer][1]
-* [Deployed Contract Addresses][3]
-
-## V1 Specs (Deprecated)
-
-| Property | Value |
-| --- | --- |
-| Disperser Address | `disperser.eigenda.xyz:443` |
-| DataAPI Address | `dataapi.eigenda.xyz` |
-| Churner Address | `churner.eigenda.xyz:443` |
-| Batch Confirmation Interval | Every 10 minutes (may vary based on network health) |
-| Max Blob Size | 16 MiB |
-| Stake Sync (AVS-Sync) Interval | Every 6 days |
-| Ejection Cooldown Period | 3 days |
 
 ## Blazar (V2) Specs
 
@@ -58,6 +45,17 @@ All other contracts are now tracked inside the EigenDADirectory contract:
 | 1 | [EIGEN](https://etherscan.io/address/0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83) |
 | 2 | [reALT](https://etherscan.io/address/0xF96798F49936EfB1a56F99Ceae924b6B8359afFb) |
 
+## V1 Specs (Deprecated)
+
+| Property | Value |
+| --- | --- |
+| Disperser Address | `disperser.eigenda.xyz:443` |
+| DataAPI Address | `dataapi.eigenda.xyz` |
+| Churner Address | `churner.eigenda.xyz:443` |
+| Batch Confirmation Interval | Every 10 minutes (may vary based on network health) |
+| Max Blob Size | 16 MiB |
+| Stake Sync (AVS-Sync) Interval | Every 6 days |
+| Ejection Cooldown Period | 3 days |
+
 [1]: https://blobs.eigenda.xyz/
 [2]: https://app.eigenlayer.xyz/avs/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0
-[3]: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment

--- a/docs/products/eigenda/networks/sepolia.md
+++ b/docs/products/eigenda/networks/sepolia.md
@@ -8,8 +8,8 @@ The EigenDA Sepolia testnet is the current EigenDA testnet for integrations.
 
 ## Quick Links
 
-* AVS Page: coming soon
-* Blob Explorer Blazar (V2): coming soon
+* [AVS Page][2]
+* [Blob Explorer Blazar (V2)][1]
 
 ## Specs
 
@@ -39,3 +39,6 @@ All other contracts are now tracked inside the EigenDADirectory contract:
 | --- | --- |
 | 0 | LSTs |
 | 1 | [WETH](https://sepolia.etherscan.io/token/0xf531b8f309be94191af87605cfbf600d71c2cfe0) |
+
+[1]: https://blobs-v2-testnet-sepolia.eigenda.xyz/
+[2]: https://sepolia.eigenlayer.xyz/avs/eigenda


### PR DESCRIPTION
Removed outdated links for deployed contract addresses 
Added links for Sepolia AVS and blob explorers 
Moved deprecated (V1) specs below V2 specs 