### PR TITLE
Remove contact link from community resources

### DIFF
--- a/docs/eigencloud/eigencloud-overview.md
+++ b/docs/eigencloud/eigencloud-overview.md
@@ -24,5 +24,3 @@ We're building EigenCloud for developers of Verifiable Apps. Each service or fea
 on reducing friction, increasing adoption, and unlocking new value. As our 1st party and partner offerings expand, EigenCloud
 will bundle them into out-of-the-box solutions on a unified developer platform.
 
-Are you interested in building on EigenCloud?  If so, please complete [this form](http://www.eigencloud.xyz/contact).  A member of the team will reach out to discuss your
-project and how we can help support your next steps.

--- a/docs/eigenlayer/developers/concepts/avs-developer-guide.md
+++ b/docs/eigenlayer/developers/concepts/avs-developer-guide.md
@@ -38,6 +38,3 @@ Examples of these services include rollup services, co-processors, cryptography 
 ![AVS Categories](/img/avs/avs-categories.png)
 
 
-## Get in Touch
-
-If you would like to discuss your ideas to build an AVS on EigenLayer, submit your contact information via [this form](https://www.eigencloud.xyz/contact) and we'll be in touch shortly.

--- a/src/components/sections/CommunityResourcesSection.js
+++ b/src/components/sections/CommunityResourcesSection.js
@@ -5,12 +5,6 @@ import styles from './CommunityResourcesSection.module.css';
 function CommunityResourcesSection() {
   const resources = [
     {
-      icon: '/img/community-avs.png',
-      title: 'Book an Intro Call →',
-      description: 'Chat with the EigenLayer team about your idea',
-      link: 'https://www.eigencloud.xyz/contact'
-    },
-    {
       icon: '/img/community-twitter.png',
       title: 'Follow us on X →',
       description: 'Stay up to date with the latest updates',


### PR DESCRIPTION
## Summary
- Removes the "Book an Intro Call" card from the Community Resources section that linked to eigencloud.xyz/contact
- The /contact page is being removed, so this card is no longer valid

## Test plan
- [ ] Verify the community resources section renders correctly with the remaining cards
- [ ] Confirm no other references to the removed card exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)