### PR TITLE
Update homepage cards: EigenCompute, EigenDA, AgentKit

### DIFF
--- a/src/components/sections/HomeHero.js
+++ b/src/components/sections/HomeHero.js
@@ -27,7 +27,7 @@ function HomeHero() {
           />
           <FigmaCard
             title="AgentKit"
-            desc="Build and deploy autonomous agents with verifiable execution."
+            desc="Build and deploy sovereign agents with verifiable execution."
             link="/agentkit/get-started/agentkit-overview"
           />
         </div>

--- a/src/components/sections/HomeHero.js
+++ b/src/components/sections/HomeHero.js
@@ -16,19 +16,19 @@ function HomeHero() {
         <div className={styles.learnTitle}>Get started building.</div>
         <div className={styles.cardsRow}>
           <FigmaCard
-            title="EigenAI"
-            desc="Verifiable, deterministic LLM inference. Available on request."
-            link="/eigenai/concepts/eigenai-overview"
-          />
-          <FigmaCard
             title="EigenCompute"
             desc="Verifiable containerized compute."
             link="/eigencompute/get-started/eigencompute-overview"
           />
           <FigmaCard
-            title="DevKit"
-            desc="Unified CLI for building EigenLayer AVSs."
-            link="/eigenlayer/developers/howto/get-started-with-devkit/start-building-task-based-avs"
+            title="EigenDA"
+            desc="High-throughput data availability for rollups and applications."
+            link="/eigenda/core-concepts/overview"
+          />
+          <FigmaCard
+            title="AgentKit"
+            desc="Build and deploy autonomous agents with verifiable execution."
+            link="/agentkit/get-started/agentkit-overview"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaces the three homepage product cards (EigenAI, EigenCompute, DevKit) with the current core products
- New order left to right: **EigenCompute**, **EigenDA**, **AgentKit**

## Test plan
- [ ] Verify homepage renders with the three updated cards
- [ ] Confirm all card links resolve to valid doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)