### PR TITLE
doc: add note for building image

### DIFF
--- a/docs/eigencompute/howto/build/persistent_storage.md
+++ b/docs/eigencompute/howto/build/persistent_storage.md
@@ -1,0 +1,58 @@
+---
+title: Persistent storage
+sidebar_position: 4
+---
+
+EigenCompute provides a persistent storage volume that survives application upgrades. The boot disk is replaced during image updates, but user data lives on an independent persistent disk that is reattached to the new VM. This means your workload state persists across upgrades, not just reboots.
+
+## Storage path
+
+All persistent data should be written to:
+
+```
+/mnt/disks/userdata
+```
+
+This path is also available via the environment variable `USER_PERSISTENT_DATA_PATH`:
+
+```bash
+echo $USER_PERSISTENT_DATA_PATH
+# /mnt/disks/userdata
+```
+
+Use this environment variable in your application code to stay forward-compatible if the mount path ever changes.
+
+## Example usage
+
+Write any data you need to persist (databases, configuration, caches) under the persistent storage path:
+
+```python
+import os
+
+data_dir = os.environ.get("USER_PERSISTENT_DATA_PATH", "/mnt/disks/userdata")
+
+# Store a SQLite database
+db_path = os.path.join(data_dir, "myapp.db")
+
+# Store application state
+state_path = os.path.join(data_dir, "state.json")
+```
+
+```go
+dataDir := os.Getenv("USER_PERSISTENT_DATA_PATH")
+if dataDir == "" {
+    dataDir = "/mnt/disks/userdata"
+}
+dbPath := filepath.Join(dataDir, "myapp.db")
+```
+
+## How it works
+
+The persistent storage volume is encrypted and managed automatically by the platform:
+
+- **With a secondary disk attached** — The volume uses a LUKS-encrypted disk that is formatted on first boot and reopened on subsequent boots.
+- **Without a secondary disk** — The platform falls back to a directory on the boot disk that is already encrypted by the platform.
+
+In both cases, the data is available at the same `/mnt/disks/userdata` path and your application code does not need to change.
+
+For more details, see the [Persistent Storage Design Spec](https://github.com/Layr-Labs/go-tpm-tools/blob/main/specs/design-persistent-storage.md).

--- a/docs/eigencompute/howto/build/verifiable-builds/build-from-verifiable-source.md
+++ b/docs/eigencompute/howto/build/verifiable-builds/build-from-verifiable-source.md
@@ -3,7 +3,7 @@ title: Build from verifiable source
 sidebar_position: 1
 ---
 
-> Importantly, if you intend to persist application data across upgrades, instruct the source to save the data at filesystem path /mnt/disks/userdata, which has been mounted at a persistent storage. More see [spec](https://github.com/Layr-Labs/go-tpm-tools/blob/main/specs/design-persistent-storage.md#35-shared-mount-point-for-both-modes).
+> Importantly, if you intend to persist application data across upgrades, instruct the source to save the data at the filesystem path /mnt/disks/userdata, which has been mounted to persistent storage. For more details, see [spec](https://github.com/Layr-Labs/go-tpm-tools/blob/main/specs/design-persistent-storage.md#35-shared-mount-point-for-both-modes). This path is also available as the environment variable USER_PERSISTENT_DATA_PATH, which is injected into the container.
 
 To build from a verifiable source, options are: 
 

--- a/docs/eigencompute/howto/build/verifiable-builds/build-from-verifiable-source.md
+++ b/docs/eigencompute/howto/build/verifiable-builds/build-from-verifiable-source.md
@@ -3,6 +3,8 @@ title: Build from verifiable source
 sidebar_position: 1
 ---
 
+> Importantly, if you intend to persist application data across upgrades, instruct the source to save the data at filesystem path /mnt/disks/userdata, which has been mounted at a persistent storage. More see [spec](https://github.com/Layr-Labs/go-tpm-tools/blob/main/specs/design-persistent-storage.md#35-shared-mount-point-for-both-modes).
+
 To build from a verifiable source, options are: 
 
 1. Use the `ecloud compute build submit` command to submit a verifiable build from a GitHub source.


### PR DESCRIPTION
When user built application from source, the source code needs to know which file path has been mounted with persistent storage.

Similarly, the user can use environmental variable to load the path