### PR TITLE
Update quickstart credit policy from  free to  match

### DIFF
--- a/docs/eigencompute/get-started/quickstart.md
+++ b/docs/eigencompute/get-started/quickstart.md
@@ -234,11 +234,11 @@ ecloud compute app deploy
 
 When prompted, select `Build and deploy from Dockerfile` option.
 
-The CLI will:
-1. Build your Docker image targeting `linux/amd64`
-2. Push the image to your Docker registry
-3. Deploy to a TEE instance
-4. Return your app details including app ID and instance IP
+The CLI:
+1. Builds your Docker image targeting `linux/amd64`
+2. Pushes the image to your Docker registry
+3. Deploys to a TEE instance
+4. Returns your app details including app ID and instance IP
 
 ### View Your Application
 

--- a/docs/eigencompute/get-started/quickstart.md
+++ b/docs/eigencompute/get-started/quickstart.md
@@ -8,7 +8,7 @@ import InteractiveDemo from '@site/src/components/InteractiveDemo';
 To build on EigenCompute:
 
 1. Place your application in a Docker container.
-2. [Subscribe to EigenCompute](billing.md). All new customers receive a $100 credit.
+2. [Subscribe to EigenCompute](billing.md). We match up to $25 on your first USDC deposit or invoice payment.
 3. Upload it to EigenCompute using the `ecloud` CLI.
 
 It's that simple to ship a verifiable application.


### PR DESCRIPTION
## Summary
- Update quickstart.md to reflect new credit policy: **$25 match on first USDC deposit or invoice payment** (instead of $100 free credits for all new customers)

## Why
- Multiple support tickets coming in from users who haven't received the $100 credit
- The old policy is no longer active, causing confusion

## Changes
- `docs/eigencompute/get-started/quickstart.md`: Updated line 11 from "All new customers receive a $100 credit" to "We match up to $25 on your first USDC deposit or invoice payment"
- Note: `billing.md` already had the correct wording ("up to $25 matched credits")

🤖 Generated with [Claude Code](https://claude.com/claude-code)