### PR TITLE
Fix documentation consistency in eigencompute get-started section

### DIFF
--- a/docs/eigencompute/get-started/billing.md
+++ b/docs/eigencompute/get-started/billing.md
@@ -1,7 +1,9 @@
 ---
 title: Billing
-sidebar_position: 3
+sidebar_position: 4
 ---
+
+# Billing
 
 Deploying an EigenCompute application to Sepolia testnet or mainnet requires an EigenCompute subscription. EigenCompute subscriptions
 can be paid by credit card or EigenCompute credits can be purchased with USDC.

--- a/docs/eigencompute/get-started/eigencompute-overview.md
+++ b/docs/eigencompute/get-started/eigencompute-overview.md
@@ -3,6 +3,8 @@ title: EigenCompute Overview
 sidebar_position: 1
 ---
 
+# EigenCompute Overview
+
 ## What is EigenCompute? 
 
 EigenCompute enables developers to deploy verifiable applications: containerized services that receive their own cryptographic identity, allowing them to hold funds, sign transactions, and operate autonomously.
@@ -56,7 +58,7 @@ in the enclave, can retrieve the private key.
 
 4. Onchain deployment record: Every deployment is permanently recorded on-chain by its Docker digest, creating an immutable audit trail.
 
-5. Network access: Optionally [expose ports](../howto/deploy/expose-ports.md) for HTTP endpoints, or [configure HTTPS](quickstart.md#tlshttps-setup-optional) with a custom domain.
+5. Network access: Optionally [expose ports](../howto/deploy/expose-ports.md) for HTTP endpoints, or [configure HTTPS](../howto/deploy/configure-tls.md) with a custom domain.
 
 This creates truly autonomous applications - code that holds its own funds with cryptographic proof of what it will do with them.
 

--- a/docs/eigencompute/get-started/quickstart.md
+++ b/docs/eigencompute/get-started/quickstart.md
@@ -5,6 +5,8 @@ sidebar_position: 2
 
 import InteractiveDemo from '@site/src/components/InteractiveDemo';
 
+# Quickstart
+
 To build on EigenCompute:
 
 1. Place your application in a Docker container.
@@ -13,7 +15,7 @@ To build on EigenCompute:
 
 It's that simple to ship a verifiable application.
 
-### See for yourself
+## See for yourself
 
 <InteractiveDemo
 steps={[
@@ -72,7 +74,7 @@ output: [
 }
 ]}
 completionMessage="🎉 That's it! Your app is deployed with its own wallet."
-ctaButton={{ text: 'Deploy Your Own →', href: '/products/eigencompute/get-started/quickstart' }}
+ctaButton={{ text: 'Deploy Your Own →', href: '/eigencompute/get-started/quickstart' }}
 />
 
 ## Next
@@ -237,7 +239,7 @@ npm run dev
 
 ### Subscribe to EigenCompute
 
-Before deploying, you'll need an [EigenCompute subscription](billing).
+Before deploying, you'll need an [EigenCompute subscription](billing.md).
 
 To subscribe:
 

--- a/docs/eigencompute/get-started/sample-apps.md
+++ b/docs/eigencompute/get-started/sample-apps.md
@@ -1,7 +1,9 @@
 ---
-title: Sample Apps 
-sidebar_position: 4
+title: Sample Apps
+sidebar_position: 5
 ---
+
+# Sample Apps
 
 See the following sample apps for examples of how EigenCompute can be used.
 


### PR DESCRIPTION
Addresses multiple documentation quality issues:

- Fix sidebar position conflicts (billing: 3→4, sample-apps: 4→5)
- Add missing H1 headings to match frontmatter titles in 4 files
- Fix broken internal links:
  - quickstart.md: Add missing .md extension to billing link
  - quickstart.md: Update deprecated CTA button path
  - eigencompute-overview.md: Fix broken HTTPS config anchor link
- Correct heading hierarchy in quickstart.md (H3→H2)
- Remove trailing whitespace in sample-apps.md frontmatter