### PR TITLE
Add ECloud SDK reference documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,43 @@ Local search is implemented using `@easyops-cn/docusaurus-search-local` plugin, 
 2. Run `yarn repomix` to regenerate files
 3. Generated files appear in `static/` directory
 
+## SDK Reference Documentation
+
+### ECloud SDK Reference
+
+The ecloud SDK reference documentation (`docs/eigencompute/reference/ecloud-sdk/`) uses a **hybrid approach**:
+- Auto-generated structure from source repository analysis
+- Manual curation of examples and best practices
+
+**Source Repository:** https://github.com/Layr-Labs/ecloud
+
+**When SDK Updates:**
+1. Analyze the ecloud repository to identify API changes
+2. Update reference docs with new methods/deprecations
+3. Update version number in documentation frontmatter
+4. Test and update code examples
+
+**Documentation Structure:**
+```
+docs/eigencompute/reference/ecloud-sdk/
+├── index.md           # Overview + getting started
+├── client.md          # Client creation & config
+├── compute/           # Compute module APIs
+├── billing.md         # Billing & subscriptions
+├── build.md           # Verifiable builds
+├── attest.md          # TEE attestation
+├── browser.md         # Browser APIs & React hooks
+├── utilities.md       # SDK utilities
+├── types.md           # TypeScript types
+└── advanced.md        # Advanced topics (EIP-7702, batching)
+```
+
+**Maintenance Notes:**
+- Mark auto-generated sections with: `<!-- AUTO-GENERATED from ecloud@v0.X.X -->`
+- Link to source code for reference: `[View source](https://github.com/...)`
+- Keep examples runnable and test with SDK updates
+- See memory: `sdk-reference-workflow.md` for detailed workflow
+
 ## Important Notes
 
 - Yarn version must be >= 1.22.22 (specified in `package.json` engines)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,21 @@ docs/eigencompute/reference/ecloud-sdk/
 - Mark auto-generated sections with: `<!-- AUTO-GENERATED from ecloud@v0.X.X -->`
 - Link to source code for reference: `[View source](https://github.com/...)`
 - Keep examples runnable and test with SDK updates
-- See memory: `sdk-reference-workflow.md` for detailed workflow
+
+**IMPORTANT - Exclude Internal Features:**
+- **`sepolia-dev` environment** - Internal development only, do NOT document
+- Any methods/features marked as internal in source code
+- When updating docs from source, always filter out internal-only items
+
+**Environment Information:**
+- **`sepolia`** - Public testnet for development and testing
+  - Prerequisites: EigenCompute subscription + Sepolia ETH for gas
+- **`mainnet-alpha`** - Production environment (Alpha phase)
+  - Prerequisites: EigenCompute subscription + mainnet ETH for gas
+  
+**Both environments require:**
+- EigenCompute subscription (see `docs/eigencompute/get-started/billing.md`)
+- Complete prerequisites (see `docs/eigencompute/get-started/quickstart.md#prerequisites`)
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Docusaurus 3.8.1-based documentation site for EigenCloud, containing multiple product documentation sections including EigenCloud, AgentKit, EigenCompute, EigenLayer, and EigenDA. The site is statically generated and deployed on Vercel.
+
+## Build & Development Commands
+
+```bash
+# Install dependencies (Yarn 1.22.22+ required)
+yarn
+
+# Start local development server (opens browser at http://localhost:3000)
+yarn start
+
+# Build for production
+yarn build
+
+# Test the production build locally
+yarn serve
+
+# Build without repomix (faster, skips external repo aggregation)
+yarn build-docusaurus
+
+# Clear Docusaurus cache and generated files
+yarn clear
+
+# Type check TypeScript files
+yarn typecheck
+
+# Check external links in documentation
+yarn check-links
+
+# Test redirects locally
+make test-redirects
+```
+
+## Architecture
+
+### Documentation Structure
+
+The site uses auto-generated sidebars from the `docs/` folder structure:
+- `docs/eigencloud/` - EigenCloud overview and legal documentation
+- `docs/agentkit/` - AgentKit product documentation
+- `docs/eigencompute/` - EigenCompute product documentation
+- `docs/eigenlayer/` - Core EigenLayer protocol documentation (developers, operators, restakers)
+- `docs/eigenda/` - EigenDA data availability documentation
+
+Each top-level directory corresponds to a sidebar defined in `sidebars.js`.
+
+### Key Configuration Files
+
+- **`docusaurus.config.js`**: Main Docusaurus configuration including:
+  - Site metadata and deployment settings
+  - Plugin configuration (redirects, search, gtag analytics)
+  - Navbar and footer structure
+  - Theme configuration and styling
+  - Custom `llms-txt-plugin` that generates concatenated markdown files for LLM consumption
+  - Extensive redirect rules (400+ redirects) mapping old paths to new structure
+  
+- **`sidebars.js`**: Defines sidebar structure for each product section using auto-generated directories
+
+- **`package.json`**: Dependencies and scripts. Note the `build` script runs `repomix` before building.
+
+### Custom Plugins
+
+The site includes a custom `pluginLlmsTxt` that:
+- Recursively reads all `.md` and `.mdx` files from specific documentation directories
+- Generates aggregated markdown files in the build output:
+  - `llms-full.md` - All documentation
+  - `avs-developer-docs.md` - EigenLayer developers docs only
+  - `operators-developer-docs.md` - Operators docs only
+  - `eigenda-docs.md` - EigenDA docs only
+  - `llms.txt` - Document index with titles and descriptions
+
+### Repomix Integration
+
+The `run-repomix.js` script fetches and processes external repositories into markdown files stored in `static/`:
+- `eigenlayer-contracts.md` from github.com/Layr-Labs/eigenlayer-contracts
+- `eigenlayer-go-sdk.md` from github.com/Layr-Labs/eigensdk-go
+- `eigenx.md` from github.com/Layr-Labs/eigenx-cli
+- `devkit.md` from github.com/Layr-Labs/devkit-cli
+
+This runs automatically during `yarn build` but can be skipped with `yarn build-docusaurus`.
+
+### Custom Components
+
+Custom React components in `src/components/`:
+- **Card components**: `Card.js`, `CommunityCard.js`, `FigmaCard.js`, `InteractiveCard.js`
+- **UI elements**: `Button.js`, `SectionHeader.js`
+- **Utilities**: `CopyToClipboard.js`, `InteractiveDemo.js`
+- **CopyMarkdownButton**: Component for copying markdown content
+- **sections/**: Various section-specific components
+
+### Redirects
+
+The site has 400+ redirect rules in `docusaurus.config.js` to maintain URL stability during documentation restructuring. Major redirect patterns:
+- `/products/<product>/` → `/<product>/` (flattening structure)
+- `/developers/` → `/eigenlayer/developers/`
+- `/operators/` → `/eigenlayer/operators/`
+- `/restakers/` → `/eigenlayer/restakers/`
+- Case normalization (e.g., `/developers/Concepts/` → `/eigenlayer/developers/concepts/`)
+
+Additional client-side redirects are handled by JavaScript files in `static/js/`.
+
+### Markdown Features
+
+The site supports:
+- **Mermaid diagrams**: Enabled via `@docusaurus/theme-mermaid`
+- **Math equations**: Using `remark-math` and `rehype-katex` (KaTeX CSS loaded from CDN)
+- **GitHub Flavored Markdown**: Via `remark-gfm`
+- **MDX components**: React components can be imported and used in `.mdx` files
+
+### Search
+
+Local search is implemented using `@easyops-cn/docusaurus-search-local` plugin, indexing all docs with English language support.
+
+### Analytics
+
+- Google Analytics via `@docusaurus/plugin-google-gtag` (tracking ID: G-EQG5VRNYHQ)
+- Plain.js analytics script
+- Cookie3 analytics integration
+
+## Documentation Conventions
+
+- All documentation files use frontmatter with `title` and optional `sidebar_position`
+- Routes are based on file paths within the `docs/` directory
+- The docs route base path is `/` (not `/docs`)
+- Broken links and broken markdown links throw errors during build (`onBrokenLinks: "throw"`)
+
+## Common Workflows
+
+### Adding New Documentation
+
+1. Create `.md` or `.mdx` file in appropriate `docs/<product>/` directory
+2. Add frontmatter with `title` and optional `sidebar_position`
+3. Sidebar updates automatically based on file structure
+4. Test locally with `yarn start`
+
+### Adding Redirects
+
+1. Add redirect rule to `redirects` array in `docusaurus.config.js`
+2. Test with `make test-redirects` (uses `ci-scripts/test_redirects_local.sh`)
+3. Verify during build that no redirect loops exist
+
+### Updating External Repository Documentation
+
+1. Modify repository URLs or output filenames in `run-repomix.js`
+2. Run `yarn repomix` to regenerate files
+3. Generated files appear in `static/` directory
+
+## Important Notes
+
+- Yarn version must be >= 1.22.22 (specified in `package.json` engines)
+- The build process requires Node.js with ES modules support (uses `import` syntax in config)
+- Environment variables can be loaded via `.env` file (see `.env.example`)
+- TypeScript is configured but primarily for editor experience; most code is JavaScript
+- The site uses Prism for syntax highlighting with Bash and Solidity language support

--- a/docs/eigencompute/reference/ecloud-sdk/_category_.json
+++ b/docs/eigencompute/reference/ecloud-sdk/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "ECloud SDK",
+  "position": 1
+}

--- a/docs/eigencompute/reference/ecloud-sdk/client.md
+++ b/docs/eigencompute/reference/ecloud-sdk/client.md
@@ -1,0 +1,271 @@
+---
+title: Client Configuration
+sidebar_position: 2
+---
+
+<!-- AUTO-GENERATED from ecloud@v0.5.0 -->
+
+# Client Configuration
+
+The ECloud SDK client is the main entry point for interacting with EigenCompute. It provides access to all SDK modules and handles authentication and network configuration.
+
+## Creating a client
+
+### Basic usage
+
+```typescript
+import { createECloudClient } from '@layr-labs/ecloud-sdk';
+
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'sepolia',
+});
+```
+
+### With custom RPC
+
+```typescript
+const client = createECloudClient({
+  privateKey: '0x...',
+  environment: 'mainnet-alpha',
+  rpcUrl: 'https://rpc.example.com',
+  verbose: true,
+});
+```
+
+### Multiple RPC endpoints (fallback)
+
+```typescript
+const client = createECloudClient({
+  privateKey: '0x...',
+  environment: 'sepolia',
+  rpcUrl: [
+    'https://rpc1.example.com',
+    'https://rpc2.example.com',
+    'https://rpc3.example.com',
+  ],
+});
+```
+
+## Configuration options
+
+### ClientConfig
+
+```typescript
+interface ClientConfig {
+  /**
+   * Private key for signing transactions
+   * Must be a hex string starting with '0x'
+   */
+  privateKey: `0x${string}`;
+  
+  /**
+   * Deployment environment
+   * - 'sepolia': Sepolia testnet
+   * - 'mainnet-alpha': Ethereum mainnet
+   */
+  environment: 'sepolia' | 'mainnet-alpha';
+  
+  /**
+   * Custom RPC URL(s) for Ethereum node connection
+   * Can be a single URL or array of URLs for fallback
+   * @default Uses environment's default RPC
+   */
+  rpcUrl?: string | string[];
+  
+  /**
+   * Enable verbose logging
+   * @default false
+   */
+  verbose?: boolean;
+}
+```
+
+## Authentication
+
+The SDK requires a private key to sign transactions. Provide it using one of these methods:
+
+### 1. Environment variable
+
+Set the `PRIVATE_KEY` environment variable:
+
+```bash
+export PRIVATE_KEY=0x...
+```
+
+```typescript
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'sepolia',
+});
+```
+
+### 2. OS keychain (using ecloud CLI)
+
+Store your key securely [using the ecloud CLI](../../howto/setup/create-use-auth-keys.md):
+
+```bash
+ecloud auth create
+```
+
+Retrieve it programmatically:
+
+```typescript
+import { requirePrivateKey } from '@layr-labs/ecloud-sdk';
+
+const privateKey = await requirePrivateKey({
+  environment: 'sepolia',
+  // Will prompt or retrieve from keychain
+});
+
+const client = createECloudClient({
+  privateKey,
+  environment: 'sepolia',
+});
+```
+
+### 3. Direct parameter
+
+Pass the private key directly (not recommended for production):
+
+```typescript
+const client = createECloudClient({
+  privateKey: '0x...',
+  environment: 'sepolia',
+});
+```
+
+:::caution Security
+Never commit private keys to source control. Use environment variables or secure key management systems in production.
+:::
+
+## Client properties
+
+Once created, the client exposes the following modules:
+
+```typescript
+const client = createECloudClient({ ... });
+
+// Access modules
+client.compute    // Compute module (app deployment & management)
+client.billing    // Billing module (subscriptions & credits)
+
+// Billing address
+client.billing.address  // Ethereum address derived from private key
+```
+
+## Environments
+
+See [Billing](../../get-started/billing.md) for subscription setup and [Prerequisites](../../get-started/quickstart.md#prerequisites) for client creation.
+
+### Sepolia (testnet)
+
+Development and testing environment on Sepolia testnet.
+
+```typescript
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'sepolia',
+});
+```
+
+### Mainnet Alpha
+
+Ethereum mainnet environment (currently in Alpha phase).
+
+```typescript
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'mainnet-alpha',
+});
+```
+
+## Verbose logging
+
+Enable detailed logging for debugging:
+
+```typescript
+const client = createECloudClient({
+  privateKey: '0x...',
+  environment: 'sepolia',
+  verbose: true,  // Enable verbose output
+});
+```
+
+When enabled, the SDK logs:
+- Transaction submissions
+- API requests
+- Deployment progress
+- Error details
+
+## Error handling
+
+```typescript
+try {
+  const client = createECloudClient({
+    privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+    environment: 'sepolia',
+  });
+  
+  // Method calls may throw
+  await client.compute.app.deploy({ ... });
+} catch (error) {
+  if (error.message.includes('insufficient funds')) {
+    console.error('Not enough ETH for gas');
+  } else {
+    console.error('Error:', error.message);
+  }
+}
+```
+
+## Best practices
+
+### 1. Use environment variables
+
+```typescript
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: (process.env.ECLOUD_ENV || 'sepolia') as 'sepolia' | 'mainnet-alpha',
+  rpcUrl: process.env.RPC_URL,
+});
+```
+
+### 2. Enable verbose logging during development
+
+```typescript
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'sepolia',
+  verbose: process.env.NODE_ENV === 'development',
+});
+```
+
+## Private key utilities
+
+### Generate a new private key
+
+```typescript
+import { generateNewPrivateKey } from '@layr-labs/ecloud-sdk';
+
+const { privateKey, address } = generateNewPrivateKey();
+console.log('Private Key:', privateKey);
+console.log('Address:', address);
+```
+
+### Validate private key format
+
+```typescript
+import { validatePrivateKeyFormat } from '@layr-labs/ecloud-sdk';
+
+const isValid = validatePrivateKeyFormat('0x...');
+if (!isValid) {
+  throw new Error('Invalid private key format');
+}
+```
+
+## Next steps
+
+- [Use ecloud SDK](../../howto/build/use-ecloud-sdk.md) - How-to guide
+- [Deploy an application](../../get-started/quickstart.md) - Quickstart guide
+- [Manage subscriptions](../../get-started/billing.md) - Billing and credits
+- [View ecloud SDK source](https://github.com/Layr-Labs/ecloud/blob/main/packages/sdk/src/client/index.ts)

--- a/docs/eigencompute/reference/ecloud-sdk/overview.md
+++ b/docs/eigencompute/reference/ecloud-sdk/overview.md
@@ -1,0 +1,179 @@
+---
+title: Overview
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+<!-- AUTO-GENERATED from ecloud@v0.5.0 -->
+
+# Overview
+
+The ECloud SDK is a TypeScript library for deploying and managing applications on the EigenCompute Trusted Execution Environment (TEE) infrastructure.
+
+## Overview
+
+The SDK provides:
+- **Application deployment** - Deploy containerized apps to TEE
+- **Lifecycle management** - Start, stop, upgrade, and terminate apps
+- **Billing and subscriptions** - Manage EigenCompute subscriptions and credits
+- **Verifiable builds** - Submit and verify reproducible builds
+- **TEE attestation** - Generate cryptographic proofs of execution
+- **Browser support** - React hooks and browser-safe APIs
+
+## Installation
+
+Install the SDK using npm or yarn:
+
+```bash
+npm install @layr-labs/ecloud-sdk
+```
+
+```bash
+yarn add @layr-labs/ecloud-sdk
+```
+
+## Quick start
+
+### 1. Create a client
+
+```typescript
+import { createECloudClient } from '@layr-labs/ecloud-sdk';
+
+const client = createECloudClient({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  environment: 'sepolia',
+  verbose: true,
+});
+
+console.log('Your address:', client.billing.address);
+```
+
+### 2. Subscribe to EigenCompute
+
+```typescript
+const result = await client.billing.subscribe({
+  productId: 'compute',
+  successUrl: 'https://example.com/success',
+  cancelUrl: 'https://example.com/cancel',
+});
+
+if (result.type === 'checkout_created') {
+  console.log('Complete subscription:', result.checkoutUrl);
+} else if (result.type === 'already_active') {
+  console.log('Already subscribed!');
+}
+```
+
+### 3. Deploy an application
+
+```typescript
+const deployment = await client.compute.app.deploy({
+  appName: 'my-app',
+  imageReference: 'myregistry/myapp:latest',
+  env: {
+    PORT: '3000',
+  },
+});
+
+console.log('App deployed!');
+console.log('App ID:', deployment.appId);
+console.log('IP Address:', deployment.ipAddress);
+```
+
+## Modules
+
+The SDK is organized into functional modules.
+
+| Module | Purpose |
+|--------|---------|
+| **[Client](client.md)** | SDK initialization and configuration |
+| **Compute** | Deploy and manage applications |
+| **Billing** | Subscriptions and credit management |
+| **Build** | Verifiable builds and provenance |
+| **Attest** | TEE attestation (run inside TEE) |
+| **Browser** | Browser-safe APIs and React hooks |
+| **Utilities** | Helper functions and validators |
+
+## Package exports
+
+The SDK provides multiple entry points:
+
+```typescript
+// Full SDK (Node.js)
+import { createECloudClient } from '@layr-labs/ecloud-sdk';
+
+// Browser-safe subset
+import { createECloudClient } from '@layr-labs/ecloud-sdk/browser';
+
+// Direct module access
+import { createComputeModule } from '@layr-labs/ecloud-sdk/compute';
+import { createBillingModule } from '@layr-labs/ecloud-sdk/billing';
+
+// Attestation module (for use inside TEE)
+import { AttestClient } from '@layr-labs/ecloud-sdk/attest';
+```
+
+## Environments
+
+The SDK supports two environments:
+
+| Environment | Network |
+|------------|---------|
+| `sepolia` | Sepolia testnet |
+| `mainnet-alpha` | Ethereum mainnet |
+
+:::important Mainnet Alpha Limitations
+- Not recommended for customer funds - Mainnet Alpha is intended to enable developers to build, test and ship applications.
+- Developer is trusted - Does not enable full verifiable and trustless execution yet.
+- No SLA - No SLAs around support and uptime of infrastructure.
+:::
+
+## TypeScript support
+
+The SDK provides comprehensive type definitions:
+
+```typescript
+import type {
+  ECloudClient,
+  DeployAppOpts,
+  AppId,
+  Environment,
+} from '@layr-labs/ecloud-sdk';
+```
+
+See the [SDK source code](https://github.com/Layr-Labs/ecloud/tree/main/packages/sdk/src) for complete type definitions.
+
+## Authentication
+
+The SDK supports multiple methods for providing your private key:
+
+1. **Environment variable**: `PRIVATE_KEY=0x...`
+2. **OS keychain**: Stored via `ecloud auth` CLI
+3. **Direct parameter**: Pass to `createECloudClient()`
+
+See the [Client reference](client.md#authentication) for details.
+
+## Error handling
+
+SDK methods throw errors when they fail. Use try-catch for error handling:
+
+```typescript
+try {
+  await client.compute.app.deploy({ ... });
+} catch (error) {
+  console.error('Deployment failed:', error.message);
+}
+```
+
+## Links
+
+- **npm package**: [@layr-labs/ecloud-sdk](https://www.npmjs.com/package/@layr-labs/ecloud-sdk)
+- **Source code**: [github.com/Layr-Labs/ecloud](https://github.com/Layr-Labs/ecloud)
+- **Current version**: v0.5.0 (May 2026)
+- **How-to guide**: [Use ecloud SDK](../../howto/build/use-ecloud-sdk.md)
+
+## Next steps
+
+- [Configure the client](client.md) - Detailed client setup
+- [Deploy an application](../../get-started/quickstart.md) - Quickstart guide
+- [Manage subscriptions](../../get-started/billing.md) - Billing and credits


### PR DESCRIPTION
Create initial ECloud SDK reference documentation with two sections:

## Overview
- SDK overview and capabilities
- Installation instructions
- Quick start guide
- Module descriptions
- Package exports
- Environments (Sepolia, Mainnet Alpha) with limitations note
- TypeScript support
- Authentication methods
- Error handling
- Links to npm package and source code

## Client configuration
- Basic usage examples
- Custom RPC configuration
- Configuration options (ClientConfig interface)
- Authentication methods (environment variable, OS keychain, direct parameter)
- Client properties
- Environment details (Sepolia, Mainnet Alpha)
- Verbose logging
- Error handling
- Best practices
- Private key utilities

## Structure
- Uses `overview.md` (not `index.md`) following EigenCloud docs pattern
- Sidebar configured via `_category_.json` with label "ECloud SDK"
- Applied Microsoft Manual of Style guidelines (sentence case, active voice, etc.)
- Includes links to related guides (billing, quickstart, auth keys)

Source: ecloud@v0.5.0 (https://github.com/Layr-Labs/ecloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)