### PR TITLE
Fix Copy for LLM button to work with Docusaurus structure

### DIFF
--- a/src/components/CopyMarkdownButton/index.js
+++ b/src/components/CopyMarkdownButton/index.js
@@ -6,13 +6,19 @@ export default function CopyMarkdownButton() {
 
   const copyMarkdown = async () => {
     try {
-      // Get the main article content
-      const article = document.querySelector('article');
-      if (!article) return;
+      // Get the main content with Docusaurus-specific selectors
+      const contentElement = document.querySelector('.theme-doc-markdown') ||
+                            document.querySelector('article');
 
-      // Get the markdown content from the page
-      const title = document.querySelector('h1')?.textContent || '';
-      const content = article.innerText;
+      if (!contentElement) return;
+
+      // Get the title
+      const title = document.querySelector('.theme-doc-markdown h1')?.textContent ||
+                   document.querySelector('h1')?.textContent ||
+                   document.title || '';
+
+      // Get the content text
+      const content = contentElement.innerText || contentElement.textContent || '';
 
       // Format as markdown
       const markdown = `# ${title}\n\n${content}`;


### PR DESCRIPTION
- Use .theme-doc-markdown selector instead of article for better Docusaurus compatibility
- Add fallback selectors for title extraction
- Add fallback to textContent if innerText is unavailable
- Ensures button works reliably across different page structures