### PR TITLE
Add Duration Vaults documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,62 @@ docs/eigencompute/reference/ecloud-sdk/
 - EigenCompute subscription (see `docs/eigencompute/get-started/billing.md`)
 - Complete prerequisites (see `docs/eigencompute/get-started/quickstart.md#prerequisites`)
 
+## Documentation Patterns for New Features
+
+When documenting new EigenLayer protocol features, follow the **minimal documentation pattern** used for Rewards v2.2 and Duration Vaults:
+
+### Pattern: Minimal Feature Documentation
+
+**Follow this approach for specialized features (not core protocol changes):**
+
+1. **Update existing overview** (`docs/eigenlayer/concepts/eigenlayer-overview.md`)
+   - Add bullet point to core components list with brief description
+   - Link to dedicated concept page
+   - Do NOT add large sections - keep overview proportional
+
+2. **Create dedicated concept page** (`docs/eigenlayer/concepts/feature-name.md`)
+   - Full explanation (~300-400 words)
+   - Include ELIP references in `:::note` block
+   - How it works, comparison tables, when to use
+   - Supported configurations/tokens
+   - Important warnings in `:::important` blocks
+
+3. **Add brief mention to relevant audience overview** (if applicable)
+   - For staker features: `docs/eigenlayer/restakers/concepts/overview.md`
+   - For operator features: `docs/eigenlayer/operators/concepts/operator-introduction.md`
+   - For developer features: `docs/eigenlayer/developers/concepts/avs-developer-guide.md`
+   - Brief (~50 word) description with link to contract docs or concept page
+   - Not all features need audience-specific mentions - only if directly relevant
+
+4. **Create developer how-to guide** (if applicable)
+   - Location: `docs/eigenlayer/developers/howto/build/feature-name.md`
+   - When to use, lifecycle, supported options
+   - Link to contract documentation for implementation details
+   - **Do NOT include code examples** - link to contract docs instead
+
+**Precedents:**
+- **Rewards v2.2** - Added via 2 file updates (PR #257)
+- **Duration Vaults** - Added via 2 file updates + 2 new concept/how-to files
+
+**Key principles:**
+- Specialized features get dedicated concept pages, not large sections in overview
+- Link to contract documentation for technical implementation details
+- Keep code examples in contract repos, not user-facing docs
+- Use comparison tables to explain vs. existing approaches
+- Always reference relevant ELIPs
+
+**File structure for specialized features:**
+```
+docs/eigenlayer/
+├── concepts/
+│   ├── eigenlayer-overview.md (bullet point mention only)
+│   └── feature-name.md (dedicated page)
+├── restakers/concepts/
+│   └── overview.md (brief mention if relevant)
+└── developers/howto/build/
+    └── feature-name.md (how-to guide, links to contract docs)
+```
+
 ## Important Notes
 
 - Yarn version must be >= 1.22.22 (specified in `package.json` engines)

--- a/docs/eigenlayer/concepts/duration-vaults.md
+++ b/docs/eigenlayer/concepts/duration-vaults.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 8
+title: Duration Vaults
+---
+
+:::note
+[ELIP-015](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-015.md) introduced Duration Vaults.
+[ELIP-017](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-017.md) enabled Duration Vaults for ETH LSTs.
+:::
+
+Duration Vaults are time-bound, single-use strategies that provide guaranteed stake commitments for specific periods. Unlike 
+traditional restaking where Stakers delegate to Operators, Duration Vaults require Stakers to delegate to the vault and deposit tokens for a fixed duration.
+
+## How Duration Vaults Work
+
+Duration Vaults operate through three phases:
+
+1. **Deposits** - Stakers delegate to the vault and deposit tokens (ETH LSTs or other ERC-20s) during an open window.
+2. **Allocations** - Vault locks deposits and allocates 100% stake to a specific Operator Set. Stake is slashable and earns rewards.
+3. **Withdrawals** - After the duration elapses, Stakers can withdraw deposits plus rewards minus any slashing.
+
+## Duration Vaults vs Traditional Restaking
+
+| Aspect | Traditional Restaking                     | Duration Vaults                                        |
+|--------|-------------------------------------------|--------------------------------------------------------|
+| **Delegation** | Delegate to Operators                     | Delegate and deposit directly to vault                 |
+| **Duration** | Perpetual, withdraw anytime (with delays) | Fixed duration commitment                              |
+| **Flexibility** | Can redelegate between operators          | Locked for vault's allocation period                   |
+
+## Supported Tokens
+
+Duration Vaults support ETH LST and other ERC-20 tokens with EigenLayer strategies. 
+
+Duration Vaults do not support EIGEN and bEIGEN, or Native ETH.
+
+## When to Use Duration Vaults
+
+For Stakers:
+- Commit stake for a specific time period in exchange for guaranteed returns.
+- Simplified staking without Operator selection complexity.
+- Time-bound services offered by AVSs (insurance coverage, prediction markets).
+
+For AVS developers:
+- Secure guaranteed capacity for a specific time period.
+- Provide predictable security commitments to end users.
+- Support time-bound use cases requiring fixed-duration stake allocations.
+
+For information on how to implement Duration Vaults, see [Create Duration Vaults](../developers/howto/build/create-duration-vaults.md).
+
+:::important
+Duration Vaults lock Staker funds for the entire allocation period. Withdrawals are not possible during the allocation period.
+:::

--- a/docs/eigenlayer/concepts/eigenlayer-overview.md
+++ b/docs/eigenlayer/concepts/eigenlayer-overview.md
@@ -36,6 +36,7 @@ The core components of the EigenLayer protocol include:
 - **Delegation** is the process where stakers delegate their restaked ETH or LSTs to Operators or run validation services themselves, effectively becoming an Operator. This process involves a double opt-in between both parties, ensuring mutual agreement.
 - EigenLayer **Rewards** enables AVSs to make rewards distributions to stakers and operators that opt-in to support the AVS. AVSs make RewardsSubmissions to the RewardsCoordinator, a core protocol contract.
 - **Slashing** is a penalty for improperly or inaccurately completing tasks assigned in Operator Sets by an AVS. A slashing results in a burning/loss of funds.
+- **Duration Vaults** are time-bound strategies enabling guaranteed stake commitments for specific periods. Stakers delegate to the vault and deposit for fixed durations. 
 
 <img src="/img/overview/eigenlayer-arch-v2.png" width="75%"
     style={{ margin: '50px'}}>

--- a/docs/eigenlayer/developers/howto/build/create-duration-vaults.md
+++ b/docs/eigenlayer/developers/howto/build/create-duration-vaults.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 3
+title: Create Duration Vaults
+---
+
+[Duration Vaults](../../../concepts/duration-vaults.md) enable AVSs to make guaranteed, time-bound stake commitments for specific Operator Sets. 
+
+## Prerequisites
+
+Before creating a Duration Vault, first [create an Operator Set](operator-sets/create-operator-sets.md) for your AVS. Your Operator Set is assigned an `operatorSetId` that is specified when deploying the vault.
+
+The Duration Vault provides guaranteed stake to that Operator Set during its allocation period. You can deploy multiple Duration Vaults (with different durations or token types) targeting the same Operator Set.
+
+## Implementation
+
+Duration Vaults are deployed permissionlessly via the `StrategyFactory`. For detailed deployment instructions and contract references, see
+the [Duration Vault Strategy contract documentation](https://github.com/Layr-Labs/eigenlayer-contracts/blob/main/docs/core/DurationVaultStrategy.md).

--- a/docs/eigenlayer/restakers/concepts/overview.md
+++ b/docs/eigenlayer/restakers/concepts/overview.md
@@ -88,6 +88,11 @@ If an Operator itself is compromised, it may stand up its own AVS to steal user 
 reputation and legitimacy of Operators when making delegations. For more information on these attack scenarios, refer to 
 [this forum post](https://forum.eigenlayer.xyz/t/risks-of-an-in-protocol-redistribution-design/14458).
 
+## Duration Vaults
+
+[Duration Vaults](../../concepts/duration-vaults.md) are time-bound strategies where Stakers delegate to the vault and deposit 
+tokens (ETH LSTs or other ERC-20s) for a fixed duration, providing guaranteed commitments. 
+
 ## Withdrawal Delay (Withdrawal Escrow)
 
 EigenLayer contracts feature a withdrawal delay for all Liquid and Native restaking, a critical security measure for instances 


### PR DESCRIPTION
Adds minimal documentation for Duration Vaults (ELIP-015, ELIP-017).

Changes:
- Added Duration Vaults concept page with lifecycle, comparison table, and supported tokens
- Added brief Duration Vaults section to restakers overview
- Added Duration Vaults bullet point to EigenLayer overview
- Added minimal developer how-to guide for creating Duration Vaults
- Document minimal feature documentation pattern in CLAUDE.md

Duration Vaults are time-bound strategies where stakers delegate to the vault and deposit tokens for fixed durations, providing guaranteed commitments for AVS use cases like insurance pools and prediction markets.