### PR TITLE
Add EIGEN token address guidance for manual withdrawals

### DIFF
--- a/docs/eigenlayer/restakers/restaking-guides/withdraw-using-smart-contract.md
+++ b/docs/eigenlayer/restakers/restaking-guides/withdraw-using-smart-contract.md
@@ -73,11 +73,15 @@ the withdrawal attempt will fail.
       startBlock: <start block number>
       strategies: [<strategy address>]
       scaledShares: [<scaledShares number>]
-      tokens: [<token address you want to withdraw. For Native ETH withdrawals, enter 0x0000000000000000000000000000000000000000>]
+      tokens: [<token address you want to withdraw. For Native ETH withdrawals, enter 0x0000000000000000000000000000000000000000. For EIGEN withdrawals, enter 0xec53bf9167f50cdeb3ae105f56099aaab9061f83>]
       receiveAsTokens: true
       ```
 
       You can specify `receiveAsTokens: false` to cancel a completable withdrawal and return the assets to fully restaked status eligible to earn rewards.
+
+      :::important EIGEN withdrawals
+      For EIGEN withdrawals, use the EIGEN token address (`0xec53bf9167f50cdeb3ae105f56099aaab9061f83`) in the `tokens` field, even though the strategy holds bEIGEN.
+      :::
 
 5. Submit the Transaction
     1. Click *Write*.


### PR DESCRIPTION
## Summary
- Adds EIGEN token address to the manual withdrawal guide
- Clarifies that EIGEN withdrawals use the EIGEN token address even though the strategy holds bEIGEN
- Includes inline example in the tokens field and an important callout

## Test plan
- [x] Verified locally in browser
- [ ] Verify rendered correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)