### PR TITLE
Add x402 top-up documentation

### DIFF
--- a/docs/eigencompute/get-started/billing.md
+++ b/docs/eigencompute/get-started/billing.md
@@ -83,6 +83,54 @@ ecloud billing top-up
 The EigenCompute wallet address and balance is displayed. If the wallet contains USDC, specify the amount to spend on credits. 
 If the wallet does not contain USDC, you are prompted to send USDC to the wallet.
 
+## Top up with x402
+
+[x402](https://www.x402.org/) is an open protocol for paying APIs with signed stablecoin messages. EigenCompute credits can be
+purchased over x402 with USDC on Base. Unlike the on-chain USDC top-up, no ETH for gas is required — you sign a USDC payment
+authorization and settlement is handled by the billing API.
+
+To purchase credits over x402:
+
+```
+ecloud billing top-up --method x402 --amount 5
+```
+
+The CLI requests a payment challenge from the billing API, signs the USDC payment with your ecloud key, and settles it. On
+success, the credits are applied to your account and the CLI prints the payment ID and settlement transaction hash.
+
+By default, credits go to the shared credit pool for your wallet. To credit a specific app instead (isolated billing), pass the
+app address:
+
+```
+ecloud billing top-up --method x402 --amount 5 --app 0xYourAppAddress
+```
+
+:::note
+The minimum x402 purchase is $5. Payment settles in USDC on Base mainnet, so your wallet needs at least the purchase amount in
+USDC on Base. No ETH is required.
+:::
+
+### Purchase credits from an agent or x402 client
+
+The endpoints implement standard x402 (version 2), so any x402-capable client can purchase credits programmatically — including
+an agent topping up its own compute. The endpoints are discoverable at:
+
+```
+GET https://billingapi.eigencloud.xyz/.well-known/x402.json
+```
+
+To purchase, POST the amount in cents to either endpoint and complete the returned `402` payment challenge with your x402 client:
+
+```
+POST https://billingapi.eigencloud.xyz/creators/{creatorAddress}/x402-credits
+{"amountCents": 500}
+
+POST https://billingapi.eigencloud.xyz/apps/{appAddress}/x402-credits
+{"amountCents": 500}
+```
+
+A successful purchase returns the credited amount, a payment ID, and the settlement transaction hash.
+
 ## Support
 
 For support, join our [Telegram channel](https://t.me/EigenCloudSupp).

--- a/docs/eigencompute/reference/ecloud-cli/billing.md
+++ b/docs/eigencompute/reference/ecloud-cli/billing.md
@@ -61,4 +61,31 @@ Display current billing status. For more information, refer to [Manage Billing](
 
 ## top-up
 
-Purchase EigenCompute credits with USDC. For more information, refer to [Manage Billing](../../get-started/billing#top-up-with-usdc)
+Purchase EigenCompute credits with USDC (on-chain), credit card, or x402. For more information, refer to
+[Top up with USDC](../../get-started/billing#top-up-with-usdc) and [Top up with x402](../../get-started/billing#top-up-with-x402).
+
+### Synopsis
+
+`ecloud billing top-up [--method usdc|card|x402] [--amount <value>] [global options]`
+
+### Options
+
+`--method=<option>` (string)
+
+> Payment method: `usdc` (on-chain transfer), `card` (credit card), or `x402` (USDC payment over x402, no gas required). Prompted if omitted.
+
+`--amount=<value>` (number)
+
+> Amount to spend, in whole dollars. The minimum x402 purchase is $5.
+
+`--chain=<option>` (string)
+
+> Network for on-chain USDC payment: `ethereum` or `base`. Applies to `--method usdc` only.
+
+`--creator=<value>` (string)
+
+> x402 only: creator address whose shared credit pool to top up. Defaults to your wallet. Mutually exclusive with `--app`.
+
+`--app=<value>` (string)
+
+> x402 only: app address to credit directly (isolated billing). Mutually exclusive with `--creator`.


### PR DESCRIPTION
## What

Documents the x402 credit-purchase path that went live on prod (`billingapi.eigencloud.xyz`) this week:

- **`docs/eigencompute/get-started/billing.md`** — new "Top up with x402" section: CLI usage (`ecloud billing top-up --method x402`), creator-pool vs per-app crediting, $5 minimum, no-gas-needed note, plus the raw HTTP endpoints (`/.well-known/x402.json` discovery, `POST /creators/{addr}/x402-credits`, `POST /apps/{addr}/x402-credits`) so agents and third-party x402 clients can purchase credits programmatically.
- **`docs/eigencompute/reference/ecloud-cli/billing.md`** — fleshed out the `top-up` command entry with the `--method`, `--amount`, `--chain`, `--creator`, `--app` flags (reference previously had no flags listed).

## Why

x402 purchasing shipped in ecloud-platform (PR #272 + #304 interop fix) and is now enabled on mainnet, but has zero user-facing docs. This gives users and agent builders enough to actually try it.

## Verification

Flow verified end-to-end 2026-07-14: prod challenge + PAYMENT-REQUIRED header interop confirmed against `billingapi.eigencloud.xyz` (Base mainnet, spec-compliant v2), and a full settlement ($5, HTTP 201, credits granted, on-chain tx confirmed) exercised via `ecloud billing top-up --method x402` against the dev host on Base Sepolia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)