### PR TITLE
Add documentation on rewards stopping during queued withdrawals

### DIFF
--- a/docs/eigenlayer/concepts/rewards/rewards-claiming-faq.md
+++ b/docs/eigenlayer/concepts/rewards/rewards-claiming-faq.md
@@ -59,3 +59,8 @@ In order for an Operator to be eligible for a reward submission they must been r
 of the reward duration. If an Operator does not meet this condition but has rewards submitted to them, the rewards are
 refunded back to the AVS address. To claim rewards as an AVS, you must set a claimer for the AVS, which can be done 
 using [`setClaimerFor`](https://github.com/Layr-Labs/eigenlayer-middleware/blob/5e2056601c69f39f29c3fe39edf9013852e83bf3/src/ServiceManagerBase.sol#L216) on the [`ServiceManagerBase`](https://github.com/Layr-Labs/eigenlayer-middleware/blob/2afed9dd5bdd874d8c41604453efceca93abbfbc/docs/ServiceManagerBase.md#L1) contract or [using the EigenLayer CLI](../../operators/howto/configurerewards/set-rewards-claimer.md).
+
+### Do rewards continue to accumulate during a queued withdrawal?
+
+No. Rewards stop accumulating when a withdrawal is queued. This applies whether you queue a withdrawal directly or if a withdrawal is automatically queued as part of an
+undelegate action. Once the escrow period ends, you can choose to either complete the withdrawal or redeposit to resume earning rewards.

--- a/docs/eigenlayer/concepts/rewards/rewards-concept.md
+++ b/docs/eigenlayer/concepts/rewards/rewards-concept.md
@@ -63,3 +63,5 @@ information on the deterministic calculation of the distribution of rewards, ref
 
 The posted distribution roots contain cumulative earnings. That is, Stakers and Operators do not have to claim against every
 root and claiming against the most recent root claims anything not yet claimed.
+
+Rewards stop accumulating when a withdrawal is queued.

--- a/docs/eigenlayer/operators/howto/claimrewards/claim-rewards-cli.mdx
+++ b/docs/eigenlayer/operators/howto/claimrewards/claim-rewards-cli.mdx
@@ -14,6 +14,8 @@ import TabItem from '@theme/TabItem';
 To be eligible for a reward submission, an Operator must have been registered to the AVS for at least a portion
 of the reward duration. If rewards submitted to them, the rewards are
 refunded back to the AVS address. To claim rewards as an AVS, you must set a [claimer for the AVS](../configurerewards/set-rewards-claimer.md).
+
+Rewards stop accumulating when a withdrawal is queued.
 :::
 
 ### Earner

--- a/docs/eigenlayer/restakers/restaking-guides/claim-rewards-app.md
+++ b/docs/eigenlayer/restakers/restaking-guides/claim-rewards-app.md
@@ -11,6 +11,10 @@ When claiming Rewards using the [EigenLayer app](https://app.eigenlayer.xyz/):
 
 To specify the [rewards recipient](../../operators/howto/claimrewards/claim-rewards-cli.mdx) or [batch claim](../../operators/howto/claimrewards/batch-claim-rewards.md), claim using the EigenLayer CLI.
 
+:::note
+Rewards stop accumulating when a withdrawal is queued.
+:::
+
 ## Earner
 
 To claim rewards using the EigenLayer app as an [Earner](../../concepts/rewards/earners-claimers-recipients.md):

--- a/docs/eigenlayer/restakers/restaking-guides/withdraw-using-smart-contract.md
+++ b/docs/eigenlayer/restakers/restaking-guides/withdraw-using-smart-contract.md
@@ -73,11 +73,15 @@ the withdrawal attempt will fail.
       startBlock: <start block number>
       strategies: [<strategy address>]
       scaledShares: [<scaledShares number>]
-      tokens: [<token address you want to withdraw. For Native ETH withdrawals, enter 0x0000000000000000000000000000000000000000>]
+      tokens: [<token address you want to withdraw. For Native ETH withdrawals, enter 0x0000000000000000000000000000000000000000. For EIGEN withdrawals, enter 0xec53bf9167f50cdeb3ae105f56099aaab9061f83>]
       receiveAsTokens: true
       ```
 
       You can specify `receiveAsTokens: false` to cancel a completable withdrawal and return the assets to fully restaked status eligible to earn rewards.
+
+      :::important EIGEN withdrawals
+      For EIGEN withdrawals, use the EIGEN token address (`0xec53bf9167f50cdeb3ae105f56099aaab9061f83`) in the `tokens` field, even though the strategy holds bEIGEN.
+      :::
 
 5. Submit the Transaction
     1. Click *Write*.


### PR DESCRIPTION
## Summary
- Added FAQ entry explaining rewards stop accumulating during queued withdrawals
- Added notes in rewards concept documentation
- Added notes in operator and restaker claiming guides
- Clarifies this applies to both direct queue and undelegate actions
- Explains users can redeposit after escrow period to resume rewards

## Test plan
- [x] Verify changes render correctly locally
- [x] Check all internal links resolve
- [ ] Review accuracy with product team

🤖 Generated with [Claude Code](https://claude.com/claude-code)