### PR TITLE
Add PaymentVault addresses and on-demand deposit guide

### DIFF
--- a/docs/eigenda/core-concepts/payments.md
+++ b/docs/eigenda/core-concepts/payments.md
@@ -123,8 +123,12 @@ disperser's `GetPaymentState` gRPC endpoint.
 
 :::important
 EigenDA proxy defaults to `--eigenda.v2.client-ledger-mode=reservation-only`
-(`EIGENDA_PROXY_EIGENDA_V2_CLIENT_LEDGER_MODE`), which will not use your on-demand deposit. Set it to
-`on-demand-only`, or `reservation-and-on-demand` to fall back to on-demand when a reservation bucket is full.
+(`EIGENDA_PROXY_EIGENDA_V2_CLIENT_LEDGER_MODE`), which does not use on-demand funds at all. In that mode the proxy
+builds a reservation ledger at startup and fails with `no reservation found for account 0x…` if the account has no
+reservation, so an on-demand-only user must change it.
+
+Set `on-demand-only` to use on-demand exclusively, or `reservation-and-on-demand` to fall back to on-demand when a
+reservation bucket is full.
 :::
 
 ### Estimating how much to deposit

--- a/docs/eigenda/core-concepts/payments.md
+++ b/docs/eigenda/core-concepts/payments.md
@@ -170,7 +170,14 @@ struct OnDemandPayment {
 }
 ```
 
-All on-demand payments share global parameters including the global symbols per period (`globalSymbolsPerPeriod`), global rate interval (`globalRatePeriodInterval`), minimum number of symbols per dispersal (`minNumSymbols`), and the price per symbol (`pricePerSymbol`).
+All on-demand payments share global parameters including the global rate (`globalSymbolsPerPeriod`), global rate interval (`globalRatePeriodInterval`), minimum number of symbols per dispersal (`minNumSymbols`), and the price per symbol (`pricePerSymbol`).
+
+:::note
+Despite its name, `globalSymbolsPerPeriod` is consumed as a **per-second** leak rate, and `globalRatePeriodInterval`
+sets the burst window rather than the rate's denominator. The sustained global limit is
+`globalSymbolsPerPeriod × 32 bytes` per second, and the maximum burst is that rate multiplied by
+`globalRatePeriodInterval`.
+:::
 
 ```solidity
 /* Constant parameters set by EigenDA governance */

--- a/docs/eigenda/core-concepts/payments.md
+++ b/docs/eigenda/core-concepts/payments.md
@@ -69,6 +69,71 @@ deposits in the `PaymentVault` contract. For reservation payments, validator nod
 each account's reservation usage using leaky bucket rate limiting. Clients can query the disperser to retrieve their own
 offchain state for on-demand usage information.
 
+## Depositing for On-Demand Bandwidth
+
+Depositing is permissionless: anyone can fund an account's on-demand balance. Reservations, by contrast, are set by
+EigenDA governance and cannot be self-served, so depositing into the `PaymentVault` is the path to get started without
+contacting the EigenDA team.
+
+:::warning
+Deposits are one-way. The current `PaymentVault` has no withdraw function and `totalDeposit` can only increase, so
+unspent funds cannot be recovered or refunded. Deposit in increments you expect to consume.
+:::
+
+### 1. Choose the account to credit
+
+Deposits are credited to an account address, and the disperser attributes usage by the address that **signs the
+dispersal request**. Fund the address corresponding to your client's signing key — for EigenDA proxy, the key set via
+`--eigenda.v2.signer-payment-key-hex` (`EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX`).
+
+Because `depositOnDemand` takes the account as a parameter, the deposit can be funded from a completely separate
+wallet. The signing key itself never needs to hold ETH.
+
+### 2. Deposit
+
+Call `depositOnDemand` on the `PaymentVault` for your network ([Mainnet](../networks/mainnet.md#contract-addresses),
+[Sepolia](../networks/sepolia.md#contract-addresses), [Hoodi](../networks/hoodi.md#contract-addresses)), passing the
+account to credit and attaching ETH as the value:
+
+```bash
+cast send $PAYMENT_VAULT "depositOnDemand(address)" $ACCOUNT_TO_CREDIT \
+  --value 0.15ether --rpc-url $RPC_URL --private-key $FUNDING_KEY
+```
+
+From a browser, use the Etherscan link for your network, then **Contract → Write as Proxy → depositOnDemand**.
+
+:::caution
+The vault's `receive`/`fallback` functions also accept deposits, but they credit `msg.sender`. A plain ETH transfer from
+an exchange, a Safe, or any wallet that is not your signing account will credit *that* sender's address, and the
+deposit cannot be moved or refunded. Prefer the explicit `depositOnDemand(address)` call.
+:::
+
+### 3. Verify the deposit
+
+Read cumulative deposits back from the vault:
+
+```bash
+cast call $PAYMENT_VAULT "getOnDemandTotalDeposits(address[])(uint80[])" "[$ACCOUNT_TO_CREDIT]" --rpc-url $RPC_URL
+```
+
+This returns total deposits, not remaining balance, since usage is metered off-chain. For remaining balance, query the
+disperser's `GetPaymentState` gRPC endpoint.
+
+### 4. Enable on-demand in your client
+
+:::important
+EigenDA proxy defaults to `--eigenda.v2.client-ledger-mode=reservation-only`
+(`EIGENDA_PROXY_EIGENDA_V2_CLIENT_LEDGER_MODE`), which will not use your on-demand deposit. Set it to
+`on-demand-only`, or `reservation-and-on-demand` to fall back to on-demand when a reservation bucket is full.
+:::
+
+### Estimating how much to deposit
+
+Cost is driven by `pricePerSymbol` and `minNumSymbols` (see [below](#on-demand-bandwidth-on-demand-payments)), both
+readable from the vault. At the current mainnet parameters, budget roughly **0.015 ETH per GiB dispersed**, with a floor
+of about **1,831 gwei per dispersal**. Because every request rounds up to `minNumSymbols` (4,096 symbols, or 128 KiB),
+many small blobs cost the same as 128 KiB blobs — batch small payloads to avoid paying the floor repeatedly.
+
 ## Low-level Specification
 
 ### On-Demand Bandwidth (On-Demand Payments)
@@ -105,7 +170,7 @@ struct OnDemandPayment {
 }
 ```
 
-All on-demand payments share global parameters including the global symbols per second (`globalSymbolsPerSecond`), global rate interval (`globalRatePeriodInterval`), minimum number of symbols per dispersal (`minNumSymbols`), and the price per symbol (`pricePerSymbol`).
+All on-demand payments share global parameters including the global symbols per period (`globalSymbolsPerPeriod`), global rate interval (`globalRatePeriodInterval`), minimum number of symbols per dispersal (`minNumSymbols`), and the price per symbol (`pricePerSymbol`).
 
 ```solidity
 /* Constant parameters set by EigenDA governance */
@@ -133,7 +198,7 @@ currently considered by the disperser when determining if a payment is valid, th
 by clients, since the value may be used in the future. The disperser also enforces a global rate limit on on-demand 
 payments.
 
-Example: Initially, EigenDA team will set the price per symbol to be `0.4470gwei`, aiming for the price of `0.015ETH/GB`, or `2000gwei/128Kib` blob dispersal. We limit the global on-demand rate to be `131072` symbols per second (`4mb/s`) and 30 second rate intervals; this allows for ~4 MiB of data to be dispersed every second on average, and the maximum single spike of dispersal to be ~120MiB over 30 seconds.
+Example: Initially, EigenDA team will set the price per symbol to be `0.4470gwei`, aiming for the price of `0.015ETH/GB`, or `2000gwei/128Kib` blob dispersal. We limit the global on-demand rate to be `131072` symbols per second (`4 MiB/s`, shared across all on-demand users) and 30 second rate intervals; this allows for ~4 MiB of data to be dispersed every second on average, and the maximum single spike of dispersal to be ~120MiB over 30 seconds.
 
 ### Reserved Bandwidth (Reservations)
 

--- a/docs/eigenda/networks/hoodi.md
+++ b/docs/eigenda/networks/hoodi.md
@@ -28,6 +28,10 @@ The EigenDA Hoodi testnet is the EigenDA testnet for operators.
 | Contract | Address |
 | --- | --- |
 | EigenDADirectory | [0x5a44e56e88abcf610c68340c6814ae7f5c4369fd](https://hoodi.etherscan.io/address/0x5a44e56e88abcf610c68340c6814ae7f5c4369fd#readProxyContract) |
+| PaymentVault | [0xc043730ec3069171961aB995801f230d70B2bFb2](https://hoodi.etherscan.io/address/0xc043730ec3069171961aB995801f230d70B2bFb2) |
+
+The `PaymentVault` is listed above because it is the one contract users interact with directly, to fund on-demand
+bandwidth. See [Payments](../core-concepts/payments.md#depositing-for-on-demand-bandwidth) for how to deposit.
 
 All other contracts are now tracked inside the EigenDADirectory contract:
 1. Click on the etherscan link above.

--- a/docs/eigenda/networks/mainnet.md
+++ b/docs/eigenda/networks/mainnet.md
@@ -27,6 +27,10 @@ sidebar_position: 1
 | Contract | Address |
 | --- | --- |
 | EigenDADirectory | [0x64AB2e9A86FA2E183CB6f01B2D4050c1c2dFAad4](https://etherscan.io/address/0x64AB2e9A86FA2E183CB6f01B2D4050c1c2dFAad4) |
+| PaymentVault | [0xb2e7ef419a2A399472ae22ef5cFcCb8bE97A4B05](https://etherscan.io/address/0xb2e7ef419a2A399472ae22ef5cFcCb8bE97A4B05) |
+
+The `PaymentVault` is listed above because it is the one contract users interact with directly, to fund on-demand
+bandwidth. See [Payments](../core-concepts/payments.md#depositing-for-on-demand-bandwidth) for how to deposit.
 
 All other contracts are now tracked inside the EigenDADirectory contract:
 1. Click on the etherscan link above.

--- a/docs/eigenda/networks/sepolia.md
+++ b/docs/eigenda/networks/sepolia.md
@@ -23,6 +23,10 @@ The EigenDA Sepolia testnet is the current EigenDA testnet for integrations.
 | Contract | Address |
 | --- | --- |
 | EigenDADirectory | [0x9620dC4B3564198554e4D2b06dEFB7A369D90257](https://sepolia.etherscan.io/address/0x9620dC4B3564198554e4D2b06dEFB7A369D90257) |
+| PaymentVault | [0x2E1BDB221E7D6bD9B7b2365208d41A5FD70b24Ed](https://sepolia.etherscan.io/address/0x2E1BDB221E7D6bD9B7b2365208d41A5FD70b24Ed) |
+
+The `PaymentVault` is listed above because it is the one contract users interact with directly, to fund on-demand
+bandwidth. See [Payments](../core-concepts/payments.md#depositing-for-on-demand-bandwidth) for how to deposit.
 
 All other contracts are now tracked inside the EigenDADirectory contract:
 1. Click on the etherscan link above.


### PR DESCRIPTION
## Problem

A user who wants to pay for EigenDA on-demand bandwidth cannot do it from the docs alone:

- **No address anywhere.** The [payments page](https://docs.eigencloud.xyz/eigenda/core-concepts/payments) documents the `depositOnDemand` signature, but no network page lists `PaymentVault` — they direct readers to resolve it by hand via `getAllNames()`/`getAddress()` on Etherscan's "Read as Proxy" tab.
- **No deposit walkthrough.** Nothing states which address to credit, and the account must be the one that *signs dispersal requests* — not an arbitrary wallet.
- **A silent-failure default.** EigenDA proxy defaults to `--eigenda.v2.client-ledger-mode=reservation-only`, which ignores an on-demand deposit entirely. A user can fund the vault correctly and still have every dispersal rejected.

Since `setReservation` is `onlyOwner` (EigenDA governance), depositing is the *only* self-serve way to pay for EigenDA. Mainnet currently has 10 on-demand depositors totaling ~2.03 ETH; this friction is a plausible contributor.

## Changes

**Network pages (mainnet, Sepolia, Hoodi)** — add `PaymentVault` to Contract Addresses with a pointer to the deposit guide. Kept scoped to this one contract, since it's the only one users call directly; everything else still resolves through `EigenDADirectory`.

**Payments page** — new "Depositing for On-Demand Bandwidth" section covering which account to credit, the `depositOnDemand` call (`cast` + Etherscan), verification via `getOnDemandTotalDeposits`, the `client-ledger-mode` requirement, and cost estimation (~0.015 ETH/GiB, ~1,831 gwei floor per dispersal, batch small payloads).

Two hazards called out explicitly:
- **`receive`/`fallback` credit `msg.sender`.** A plain ETH transfer from a Safe or exchange permanently credits that sender's address. Combined with no withdraw function, the funds are unrecoverable.
- **Deposits are one-way** — already in the low-level spec, now surfaced where someone is about to send ETH.

**Two accuracy fixes:** `globalSymbolsPerSecond` → `globalSymbolsPerPeriod` (the former getter does not exist), and noting the 4 MiB/s global on-demand rate is shared across all users, not per-account.

## Verification

Addresses resolved from each network's `EigenDADirectory` via `getAddress("PAYMENT_VAULT")` and confirmed to have bytecode and respond to `PaymentVault` calls:

| Network | PaymentVault |
| --- | --- |
| Mainnet | `0xb2e7ef419a2A399472ae22ef5cFcCb8bE97A4B05` |
| Sepolia | `0x2E1BDB221E7D6bD9B7b2365208d41A5FD70b24Ed` |
| Hoodi | `0xc043730ec3069171961aB995801f230d70B2bFb2` |

Pricing figures read live from mainnet: `pricePerSymbol` = 447000000 wei, `minNumSymbols` = 4096, `globalSymbolsPerPeriod` = 131072, `globalRatePeriodInterval` = 30. Flag and env var names taken from `api/proxy/docs/help_out.txt` in Layr-Labs/eigenda.

**Not built locally.** `yarn install` fails on this repo for me regardless of Yarn version — `.yarnrc` pins `.yarn/releases/yarn-1.22.22.cjs`, which isn't present, while `.yarnrc.yml` selects Berry, so installs resolve to Yarn 4 and reject the v1 lockfile. Changes are markdown-only (no config, lockfile, or new files); all relative links and heading anchors were verified to resolve, but please confirm via the Vercel preview since `onBrokenLinks` is `throw`. Happy to hear the intended local setup if others hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)